### PR TITLE
chore: update icon URL to use centralized icons path

### DIFF
--- a/screenly.yml
+++ b/screenly.yml
@@ -2,7 +2,7 @@
 syntax: manifest_v1
 id: 01HKT2K8GVE8P6RE36QFKPG5G1
 description: Screenly Clock Edge App
-icon: https://playground.srly.io/edge-apps/clock/static/img/icon.svg
+icon: https://playground.srly.io/edge-apps/icons/clock.svg
 author: Screenly, Inc.
 categories:
   - Utilities

--- a/screenly_qc.yml
+++ b/screenly_qc.yml
@@ -2,7 +2,7 @@
 syntax: manifest_v1
 id: 01JZHR7YXWK81TNPY9F9JKQ5H4
 description: Screenly Clock Edge App
-icon: https://playground.srly.io/edge-apps/clock/static/img/icon.svg
+icon: https://playground.srly.io/edge-apps/icons/clock.svg
 author: Screenly, Inc.
 categories:
   - Utilities


### PR DESCRIPTION
## Summary

- Updates the icon URL in `screenly.yml` and `screenly_qc.yml` to point to the new centralized location (`edge-apps/icons/clock.svg`) instead of the old per-app path (`edge-apps/clock/static/img/icon.svg`)
- Aligns with the icon migration introduced in [Screenly/Playground#845](https://github.com/Screenly/Playground/pull/845)