### PR TITLE
chore: migrate formatting from prettier to edge-apps-scripts

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://json.schemastore.org/prettierrc",
-  "semi": false,
-  "singleQuote": true,
-  "printWidth": 80
-}

--- a/package.json
+++ b/package.json
@@ -13,16 +13,15 @@
     "test": "bun test src/",
     "test:unit": "bun test src/",
     "lint": "edge-apps-scripts lint --fix",
-    "format": "prettier --write src/ README.md index.html",
-    "format:check": "prettier --check src/ README.md index.html",
+    "format": "edge-apps-scripts format src/ README.md index.html",
+    "format:check": "edge-apps-scripts format --check src/ README.md index.html",
     "deploy": "bun run build && screenly edge-app deploy --path=dist/",
     "type-check": "edge-apps-scripts type-check",
     "screenshots": "edge-apps-scripts screenshots"
   },
   "dependencies": {
-    "@screenly/edge-apps": "^1.0.0"
+    "@screenly/edge-apps": "^1.2.0"
   },
-  "prettier": "./.prettierrc.json",
   "devDependencies": {
     "@playwright/test": "^1.60.0",
     "@types/bun": "^1.3.14",
@@ -30,7 +29,6 @@
     "bun-types": "^1.3.14",
     "jsdom": "^29.1.1",
     "npm-run-all2": "^9.0.1",
-    "prettier": "^3.8.3",
     "typescript": "^6.0.3"
   }
 }


### PR DESCRIPTION
- Remove `.prettierrc.json` and `prettier` dependency
- Update `format`/`format:check` scripts to use `edge-apps-scripts`
- Bump `@screenly/edge-apps` to `^1.2.0`