### PR TITLE
chore: move @screenly/edge-apps to devDependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,11 +4,9 @@
   "workspaces": {
     "": {
       "name": "clock",
-      "dependencies": {
-        "@screenly/edge-apps": "^1.0.0",
-      },
       "devDependencies": {
         "@playwright/test": "^1.60.0",
+        "@screenly/edge-apps": "^1.0.0",
         "@types/bun": "^1.3.14",
         "@types/jsdom": "^28.0.3",
         "bun-types": "^1.3.14",

--- a/package.json
+++ b/package.json
@@ -19,11 +19,10 @@
     "type-check": "edge-apps-scripts type-check",
     "screenshots": "edge-apps-scripts screenshots"
   },
-  "dependencies": {
-    "@screenly/edge-apps": "^1.0.0"
-  },
+  "dependencies": {},
   "prettier": "./.prettierrc.json",
   "devDependencies": {
+    "@screenly/edge-apps": "^1.0.0",
     "@playwright/test": "^1.60.0",
     "@types/bun": "^1.3.14",
     "@types/jsdom": "^28.0.3",


### PR DESCRIPTION
Move `@screenly/edge-apps` from `dependencies` to `devDependencies` since it is only needed at build time, not at runtime.